### PR TITLE
Reparametrise lognormal to use mean parameter.

### DIFF
--- a/shedding/models/gamma.py
+++ b/shedding/models/gamma.py
@@ -78,7 +78,7 @@ class GammaModel(util.Model):
 
         return util.merge_data(data, load=load, patient_mean=patient_mean)
 
-    def _evaluate_statistic(self, x, statistic, n):
+    def _evaluate_statistic(self, x, statistic, n, **kwargs):
         if statistic == 'mean':
             return x['population_shape'] / x['population_scale']
         elif statistic in ('var', 'std'):
@@ -89,7 +89,7 @@ class GammaModel(util.Model):
             return np.sqrt(var)
         raise ValueError(statistic)
 
-    def _evaluate_observed_likelihood_contributions(self, x, data, n=1000):
+    def _evaluate_observed_likelihood_contributions(self, x, data, n=1000, **kwargs):
         patient_mean = np.random.gamma(x['population_shape'], 1 / x['population_scale'],
                                        (n, data['num_patients']))
         patient_scale = np.repeat(x['patient_shape'] / patient_mean, data['num_samples_by_patient'],

--- a/shedding/models/util.py
+++ b/shedding/models/util.py
@@ -272,7 +272,7 @@ class Model:
         raise NotImplementedError(f'{self.__class__} does not support replication')
 
     @broadcast_samples
-    def evaluate_statistic(self, sample, statistic, n=1000):
+    def evaluate_statistic(self, sample, statistic, n=1000, **kwargs):
         """
         Evaluate a statistic of the model (using simulation where necessary).
 
@@ -321,10 +321,10 @@ class Model:
             patient_likelihood[idx] += likelihood
         return patient_likelihood
 
-    def _evaluate_statistic(self, sample, statistic, n):
+    def _evaluate_statistic(self, sample, statistic, n, **kwargs):
         raise NotImplementedError(f'{self.__class__} does not support evaluation of statistics')
 
-    def _evaluate_observed_likelihood_contributions(self, x, data, n=1000):
+    def _evaluate_observed_likelihood_contributions(self, x, data, n=1000, **kwargs):
         """
         Evaluate contributions to the observed data likelihood for each sample.
 
@@ -364,7 +364,7 @@ class InflationMixin:
         )
         return patient_likelihood
 
-    def _evaluate_statistic(self, x, statistic, n):
+    def _evaluate_statistic(self, x, statistic, n, **kwargs):
         if statistic == 'mean':
             return x['rho'] * super(InflationMixin, self)._evaluate_statistic(x, statistic, n)
         raise ValueError(statistic)

--- a/shedding/models/weibull.py
+++ b/shedding/models/weibull.py
@@ -84,13 +84,13 @@ class WeibullModel(util.Model):
         load = weibull_rng(x['patient_shape'], patient_scale, data['num_samples'])
         return util.merge_data(data, load=load, patient_mean=patient_mean)
 
-    def _evaluate_statistic(self, x, statistic, n):
+    def _evaluate_statistic(self, x, statistic, n, **kwargs):
         if statistic == 'mean':
             return x['population_scale'] * special.gamma(1 / x['population_shape']) / \
                 x['population_shape']
         raise ValueError
 
-    def _evaluate_observed_likelihood_contributions(self, x, data, n=1000):
+    def _evaluate_observed_likelihood_contributions(self, x, data, n=1000, **kwargs):
         patient_mean = weibull_rng(x['population_shape'], x['population_scale'],
                                    (n, data['num_patients']))
         patient_scale = patient_mean / special.gamma(1 + 1 / x['patient_shape'])


### PR DESCRIPTION
This PR brings the lognormal distribution in line with the gamma and Weibull distributions: the population-level model generates the mean of the patient-level distribution. Previously, the lognormal model was parametrised such that the population-level model generated the mode.