### PR TITLE
Rename population_mean to population_loc for clarity.

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,7 +19,7 @@ def test_model_code(model):
 @pytest.fixture
 def hyperparameters(model):
     if isinstance(model, shedding.LognormalModel):
-        params = {'patient_scale': 1, 'population_scale': 1, 'population_mean': 1}
+        params = {'patient_scale': 1, 'population_scale': 1, 'population_loc': 1}
     elif isinstance(model, shedding.GammaModel):
         params = {'patient_shape': 1, 'population_scale': 1e-5, 'population_shape': 1}
     elif isinstance(model, shedding.WeibullModel):


### PR DESCRIPTION
The parameter in the lognormal model was renamed from `population_mean` to `population_loc` because the former can be misleading: the mean of the population is actually `exp(population_loc + population_scale ^ 2 / 2`.